### PR TITLE
`list` calls to `policy-admin` endpoint failing + allow `list` to be called with `filter_expression` where available.

### DIFF
--- a/src/britive/britive.py
+++ b/src/britive/britive.py
@@ -490,11 +490,9 @@ class Britive:
                 params = {}  # the next-page header has all the URL parameters we need so unset them here
             elif pagination_type == 'secmgr':
                 return_data += result['result']
-                next_page = result['pagination'].get('next', '')
-                if next_page == '':
+                url = result['pagination'].get('next', '')
+                if url == '':
                     break
-                else:
-                    params['pageToken'] = next_page
             else:  # we are not dealing with pagination so just return the response as-is
                 return_data = result
                 break

--- a/src/britive/system/permissions.py
+++ b/src/britive/system/permissions.py
@@ -9,14 +9,19 @@ class SystemPermissions:
         if identifier_type not in ['id', 'name']:
             raise ValueError(f'identifier_type of {identifier_type} is invalid. Only `name` and `id` are allowed.')
 
-    def list(self) -> list:
+    def list(self, filter_expression: str = '') -> list:
         """
         List system level permissions.
 
+        :param filter_expression: Filter based on `name`. Valid operators are `eq`, `sw`, and
+            `co`. Example: name co view
         :returns: List of permissions.
         """
 
-        return self.britive.get(self.base_url)
+        params = {}
+        if filter_expression:
+            params['filter'] = filter_expression
+        return self.britive.get(self.base_url, params=params)
 
     def get(self, permission_identifier: str, identifier_type: str = 'name') -> dict:
         """

--- a/src/britive/system/policies.py
+++ b/src/britive/system/policies.py
@@ -12,14 +12,19 @@ class SystemPolicies:
         if identifier_type not in ['id', 'name']:
             raise ValueError(f'identifier_type of {identifier_type} is invalid. Only `name` and `id` are allowed.')
 
-    def list(self) -> list:
+    def list(self, filter_expression: str = '') -> list:
         """
         List system level policies (not including policies for secrets manager or profiles).
 
+        :param filter_expression: Filter based on `name`. Valid operators are `eq`, `sw`, and
+            `co`. Example: name co policy
         :returns: List of policies.
         """
 
-        return self.britive.get(self.base_url)
+        params = {}
+        if filter_expression:
+            params['filter'] = filter_expression
+        return self.britive.get(self.base_url, params=params)
 
     def get(self, policy_identifier: str, identifier_type: str = 'name', verbose: bool = False,
             condition_as_dict: bool = False) -> dict:

--- a/src/britive/system/roles.py
+++ b/src/britive/system/roles.py
@@ -9,14 +9,19 @@ class SystemRoles:
         if identifier_type not in ['id', 'name']:
             raise ValueError(f'identifier_type of {identifier_type} is invalid. Only `name` and `id` are allowed.')
 
-    def list(self) -> list:
+    def list(self, filter_expression: str = '') -> list:
         """
         List system level roles.
 
+        :param filter_expression: Filter based on `name`. Valid operators are `eq`, `sw`, and
+            `co`. Example: name co security
         :returns: List of roles.
         """
 
-        return self.britive.get(self.base_url)
+        params = {}
+        if filter_expression:
+            params['filter'] = filter_expression
+        return self.britive.get(self.base_url, params=params)
 
     def get(self, role_identifier: str, identifier_type: str = 'name', verbose: bool = False) -> dict:
         """


### PR DESCRIPTION
`TypeError` when attempting to set a key value when `params` is still default of `NoneType` 